### PR TITLE
Change the order of directories

### DIFF
--- a/exercises/02-explore-basic-service/README.md
+++ b/exercises/02-explore-basic-service/README.md
@@ -12,9 +12,10 @@ As a classic CAP based service, the core components are to be found within the l
 
 |Organizational Layer|Directory|Content|
 |-|-|-|
-|Application|`app/`|Very little, as this is a "headless" service, although some annotations are provided at this layer (in [fiori.cds](../../incidents/app/fiori.cds)) to augment the SAP Fiori elements frontend pages which CAP provides out of the box.|
-|Service|`srv/`|The single service, defined in [incidents-service.cds](../../incidents/srv/incidents-service.cds), exposing entities from the persistence layer below, in a lightweight and fairly "transparent" way.|
 |Persistence|`db/`|The actual entity definitions complete with property details, relationships, supporting artifacts such as enumerations, and even some basic annotations, defined in [schema.cds](../../incidents/db/schema.cds) (there are CSV files providing some sample data for each entity at this layer too).|
+|Service|`srv/`|The single service, defined in [incidents-service.cds](../../incidents/srv/incidents-service.cds), exposing entities from the persistence layer below, in a lightweight and fairly "transparent" way.|
+|Application|`app/`|Very little, as this is a "headless" service, although some annotations are provided at this layer (in [fiori.cds](../../incidents/app/fiori.cds)) to augment the SAP Fiori elements frontend pages which CAP provides out of the box.|
+
 
 👉 Take a few moments to look through these directories and become familiar with their contents.
 


### PR DESCRIPTION
Since the annotation file is by far the most complicated one, maybe we should first introduce `db`, then `srv`, then `app`.
What do you think?