### PR TITLE
Improve sandbox profile example

### DIFF
--- a/exercises/09-set-up-remote-system-configuration/README.md
+++ b/exercises/09-set-up-remote-system-configuration/README.md
@@ -175,9 +175,9 @@ If we were to add this information within a "sandbox" profile, it would look lik
       "kind": "sql"
     },
     "API_BUSINESS_PARTNER": {
+      "kind": "odata-v2",
+      "model": "srv/external/API_BUSINESS_PARTNER",
       "[sandbox]": {
-        "kind": "odata-v2",
-        "model": "srv/external/API_BUSINESS_PARTNER",
         "credentials": {
           "url": "https://sandbox.api.sap.com/s4hanacloud/sap/opu/odata/sap/API_BUSINESS_PARTNER/",
           "headers": {


### PR DESCRIPTION
I think the sandbox profile should only affect the credentials section of the requires configuration. The other information should be kept profile independent. This better showcases that the profile only contributes binding configuration.