### PR TITLE
Add .env to gitignore

### DIFF
--- a/incidents/.gitignore
+++ b/incidents/.gitignore
@@ -20,6 +20,7 @@ mta_archives/
 
 # Other
 .DS_Store
+.env
 *.orig
 *.log
 


### PR DESCRIPTION
Add .env to .gitignore file so it doesn't get commited into possible git environments (and possibly get public). 
greetings from the SAP CodeJam Munich. 